### PR TITLE
pin-609: Relationship status lowercase

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -334,9 +334,9 @@ components:
         status:
           type: string
           enum:
-            - Pending
-            - Active
-            - Inactive
+            - pending
+            - active
+            - inactive
       additionalProperties: false
       required:
         - from

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/partyprocess/api/impl/ProcessApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/partyprocess/api/impl/ProcessApiServiceImpl.scala
@@ -350,7 +350,8 @@ class ProcessApiServiceImpl(
         from = item.from,
         role = item.role.toString,
         platformRole = item.platformRole,
-        status = item.status.toString
+        // TODO This conversion is temporary, while we implement a naming convention for enums
+        status = item.status.toString.toLowerCase
       )
     )
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -14,7 +14,7 @@
         <appender-ref ref="CONSOLE" />
     </appender>
 
-    <root level="DEBUG">
+    <root level="OFF">
         <appender-ref ref="ASYNC"/>
     </root>
 

--- a/src/test/scala/it/pagopa/pdnd/interop/uservice/partyprocess/PartyProcessSpec.scala
+++ b/src/test/scala/it/pagopa/pdnd/interop/uservice/partyprocess/PartyProcessSpec.scala
@@ -498,11 +498,11 @@ class PartyProcessSpec
         from = taxCode1,
         role = "Manager",
         platformRole = "admin",
-        status = "Active"
+        status = "active"
       ),
-      RelationshipInfo(from = taxCode2, role = "Delegate", platformRole = "admin", status = "Active"),
-      RelationshipInfo(from = taxCode3, role = "Operator", platformRole = "security", status = "Active"),
-      RelationshipInfo(from = taxCode4, role = "Operator", platformRole = "api", status = "Active"))
+      RelationshipInfo(from = taxCode2, role = "Delegate", platformRole = "admin", status = "active"),
+      RelationshipInfo(from = taxCode3, role = "Operator", platformRole = "security", status = "active"),
+      RelationshipInfo(from = taxCode4, role = "Operator", platformRole = "api", status = "active"))
 
     }
   }


### PR DESCRIPTION
This PR change the case of the relationship enum from `Capitalized` to `lowercase`.

This is a temporary change while we implement a naming convention for enums